### PR TITLE
Update to specs2 4.0.2 and scalaz 7.2.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,14 @@ matrix:
       scala: 2.11.9
       env: SPECS2_VERSION=3.9.1
     - jdk: oraclejdk8
-      scala: 2.12.2
+      scala: 2.12.4
       env: SPECS2_VERSION=3.9.1
+    - jdk: oraclejdk8
+      scala: 2.11.9
+      env: SPECS2_VERSION=4.0.2
+    - jdk: oraclejdk8
+      scala: 2.12.4
+      env: SPECS2_VERSION=4.0.2
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ resolvers += "bintray-djspiewak-maven" at "https://dl.bintray.com/djspiewak/mave
 libraryDependencies += "com.codecommit" %% "smock" % "0.3-specs2-3.9.1" % "test"
 ```
 
-Depends on **scalaz 7.2.13**.  Cross-builds are available for Scala 2.12 and 2.11.  Different builds are published for various specs2 versions.  Specifically:
+Depends on **scalaz 7.2.18**.  Cross-builds are available for Scala 2.12 and 2.11.  Different builds are published for various specs2 versions.  Specifically:
 
-- Specs3 3.9.1
+- Specs2 4.0.2
   + Scala 2.11
   + Scala 2.12
-- Specs3 3.8.4
+- Specs2 3.9.1
+  + Scala 2.11
+  + Scala 2.12
+- Specs2 3.8.4
   + Scala 2.11
 
 A quick example stolen from the current version of the spec:


### PR DESCRIPTION
As discussed in PR for quasar, I bumped versions here.
Specs2 3.9.1 -> 4.0.2
scalaz 7.2.13 -> 7.2.18 - not necessary, I can revert if needed
scala 2.12.2 -> 2.12.4 - not necessary either
I also made release and testAll commands somehow more generic.